### PR TITLE
Update ITEM_BP.tsv lines 8475 - 8525

### DIFF
--- a/ITEM_BP.tsv
+++ b/ITEM_BP.tsv
@@ -8472,54 +8472,54 @@ ITEM_20151102_008471
 ITEM_20151102_008472
 ITEM_20151102_008473
 ITEM_20151102_008474
-ITEM_20151102_008475
-ITEM_20151102_008476
-ITEM_20151102_008477
-ITEM_20151102_008478
-ITEM_20151102_008479
-ITEM_20151102_008480
-ITEM_20151102_008481
-ITEM_20151102_008482
-ITEM_20151102_008483
-ITEM_20151102_008484
-ITEM_20151102_008485
-ITEM_20151102_008486
-ITEM_20151102_008487
-ITEM_20151102_008488
-ITEM_20151102_008489
-ITEM_20151102_008490
-ITEM_20151102_008491
-ITEM_20151102_008492
-ITEM_20151102_008493
-ITEM_20151102_008494
-ITEM_20151102_008495
-ITEM_20151102_008496
-ITEM_20151102_008497
-ITEM_20151102_008498
-ITEM_20151102_008499
-ITEM_20151102_008500
-ITEM_20151102_008501
-ITEM_20151102_008502
-ITEM_20151102_008503
-ITEM_20151102_008504
-ITEM_20151102_008505
-ITEM_20151102_008506
-ITEM_20151102_008507
-ITEM_20151102_008508
-ITEM_20151102_008509
-ITEM_20151102_008510
-ITEM_20151102_008511
-ITEM_20151102_008512
-ITEM_20151102_008513
-ITEM_20151102_008514
-ITEM_20151102_008515
-ITEM_20151102_008516
-ITEM_20151102_008517
-ITEM_20151102_008518
-ITEM_20151102_008519
-ITEM_20151102_008520
-ITEM_20151102_008521
-ITEM_20151102_008522
-ITEM_20151102_008523
-ITEM_20151102_008524
-ITEM_20151102_008525
+ITEM_20151102_008475	Pele de Lepus Bunny Killer
+ITEM_20151102_008476	Pele de Green Lepus Bunny Killer. Aparenta igual a pele de Lepus Bunny normal, mas parece reter melhor o calor.
+ITEM_20151102_008477	Comida de Emergência de Siaulav Mage
+ITEM_20151102_008478	Comida de emergência carregada por Siaulav Mages para seus semelhantes, conhecida pela sua forma de preparo.
+ITEM_20151102_008479	Cogumelo Azul de Lafseif
+ITEM_20151102_008480	Madeira Seca
+ITEM_20151102_008481	Contador de Batalha
+ITEM_20151102_008482	Um item mágico usado para contar o número de inimigos que você derrotou. Usado durante os testes de Peltasta.
+ITEM_20151102_008483	Partes de Lança Quebrada de Hoplites
+ITEM_20151102_008484	Pedaços de Armadura Quebrada de Hoplites 
+ITEM_20151102_008485	Restos de armadura quebrada durante combate entre Hoplites
+ITEM_20151102_008486	Um líquido medicinal especial para ser consumido por barbarians durante o treinamento em sua cidade natal. Intencionalmente reduz a força de quem bebe. O efeito pode ser manualmente desabilitado.
+ITEM_20151102_008487	Disco de Metal/Madeira/Pedra Suspeito
+ITEM_20151102_008488	Um grande disco redondo de aparência suspeita. Dizem que brilha vermelho quando certas condições forem cumpridas.
+ITEM_20151102_008489	Caco Vermelho do Lago	
+ITEM_20151102_008490	Um caco pequeno que emite um brilho vermelho, com origem desconhecida.
+ITEM_20151102_008491	Carne de Chafperor
+ITEM_20151102_008492	Oferenda do Lago
+ITEM_20151102_008493	Diário parcialmente queimado de um Lago
+ITEM_20151102_008494	Um diário parcialmente queimado. Difícil de ler devido a partes aleatoriamente queimadas.
+ITEM_20151102_008495	Anotação baseada no Diário da Neta
+ITEM_20151102_008496	Uma coleção de anotações baseadas nas transcrições do diário parcialmente queimado. "Xº Experimento bem sucedido, ---- está contaminando a água sem problemas. Continuarei monitorando o progresso da fruta gigantesca da floresta. Adicionalmente, um método de proteção para ---- é necessário."
+ITEM_20151102_008497	Pintura Parcialmente Queimada
+ITEM_20151102_008498	Uma pintura parcialmente queimada. Tudo exceto a pintura parece ter sido completamente queimado. A pintura mostra uma gema vermelha e Hydra com gema vermelha em seu corpo.
+ITEM_20151102_008499	Erva Azul do Lago
+ITEM_20151102_008500	Uma erva azul com um cheiro peculiar que cresce ao redor do lago. Provavelmente usada em iscas para eliminar o cheiro humano.
+ITEM_20151102_008501	Carne do Lago
+ITEM_20151102_008502	Carne de um monstro. Usada para fazer a isca que as Hydras adoram.
+ITEM_20151102_008503	Erva Amarela do Lago
+ITEM_20151102_008504	Uma erva amarela que cresce perto do lago. Alivia a dor.
+ITEM_20151102_008505	Óleo Especial do Lago
+ITEM_20151102_008506	Óleo feito de gordura.
+ITEM_20151102_008507	Banha de Chaperer
+ITEM_20151102_008508	Banha de Monstro. Pode ser usada para fazer óleo.
+ITEM_20151102_008509	Isca Espécial de Tyronas Hydra
+ITEM_20151102_008510	Isca Completa. Tyronas Hydra adora isso. 
+ITEM_20151102_008511	Saco com Oferendas
+ITEM_20151102_008512	Bússola da Procura Mágica
+ITEM_20151102_008513	Mostra os locais próximos onde a magia se acumula.
+ITEM_20151102_008514	Esfera Mágica Vazia
+ITEM_20151102_008515	Esfera de Cristal dada por Mihail. Você pode coletar magia atacando monstros.
+ITEM_20151102_008516	Esfera Mágica Carregada
+ITEM_20151102_008517	Esfera de Cristal carregada com magia. Mihail planeja usar isso como uma bomba.
+ITEM_20151102_008518	Amuleto da Dissipação Mágica
+ITEM_20151102_008519	Um amuleto preparado por Melchioras. Pode dissipar um feitiço esgotando o poder mágico dentro de um artefato.
+ITEM_20151102_008520	Coleção de Esferas Mágicas
+ITEM_20151102_008521	Esferas Mágicas coletadas por todos, em parceria com Mihail e seus amigos.
+ITEM_20151102_008522	Cartas Não Enviadas
+ITEM_20151102_008523	Cartas que ainda não foram enviadas pelos moradores de Castlefield, antes deles desaparecerem.
+ITEM_20151102_008524	Flecha Usável
+ITEM_20151102_008525	Já foi usada uma vez mas ainda parece estar em boas condições.

--- a/ITEM_BP.tsv
+++ b/ITEM_BP.tsv
@@ -8473,21 +8473,21 @@ ITEM_20151102_008472
 ITEM_20151102_008473
 ITEM_20151102_008474
 ITEM_20151102_008475	Pele de Lepus Bunny Killer
-ITEM_20151102_008476	Pele de Green Lepus Bunny Killer. Aparenta igual a pele de Lepus Bunny normal, mas parece reter melhor o calor.
-ITEM_20151102_008477	Comida de Emergência de Siaulav Mage
-ITEM_20151102_008478	Comida de emergência carregada por Siaulav Mages para seus semelhantes, conhecida pela sua forma de preparo.
+ITEM_20151102_008476	Pele de Green Lepus Bunny Killer. Aparenta ser igual a pele de Lepus Bunny normal, mas parece reter melhor o calor.
+ITEM_20151102_008477	Comida de Emergência de Siaulav Mago
+ITEM_20151102_008478	Comida de emergência carregada por Siaulav Magos para seus semelhantes, conhecida pela sua forma de preparo.
 ITEM_20151102_008479	Cogumelo Azul de Lafseif
 ITEM_20151102_008480	Madeira Seca
 ITEM_20151102_008481	Contador de Batalha
 ITEM_20151102_008482	Um item mágico usado para contar o número de inimigos que você derrotou. Usado durante os testes de Peltasta.
-ITEM_20151102_008483	Partes de Lança Quebrada de Hoplites
-ITEM_20151102_008484	Pedaços de Armadura Quebrada de Hoplites 
-ITEM_20151102_008485	Restos de armadura quebrada durante combate entre Hoplites
-ITEM_20151102_008486	Um líquido medicinal especial para ser consumido por barbarians durante o treinamento em sua cidade natal. Intencionalmente reduz a força de quem bebe. O efeito pode ser manualmente desabilitado.
+ITEM_20151102_008483	Partes de Lança Quebrada de Hoplitas
+ITEM_20151102_008484	Pedaços de Armadura Quebrada de Hoplitas 
+ITEM_20151102_008485	Restos de armadura quebrada durante combate entre Hoplitas
+ITEM_20151102_008486	Um líquido medicinal especial para ser consumido por bárbaros durante o treinamento em sua cidade natal. Intencionalmente reduz a força de quem bebe. O efeito pode ser manualmente desabilitado.
 ITEM_20151102_008487	Disco de Metal/Madeira/Pedra Suspeito
 ITEM_20151102_008488	Um grande disco redondo de aparência suspeita. Dizem que brilha vermelho quando certas condições forem cumpridas.
-ITEM_20151102_008489	Caco Vermelho do Lago	
-ITEM_20151102_008490	Um caco pequeno que emite um brilho vermelho, com origem desconhecida.
+ITEM_20151102_008489	Fragmento Vermelho do Lago	
+ITEM_20151102_008490	Um fragmento pequeno que emite um brilho vermelho, com origem desconhecida.
 ITEM_20151102_008491	Carne de Chafperor
 ITEM_20151102_008492	Oferenda do Lago
 ITEM_20151102_008493	Diário parcialmente queimado de um Lago
@@ -8506,7 +8506,7 @@ ITEM_20151102_008505	Óleo Especial do Lago
 ITEM_20151102_008506	Óleo feito de gordura.
 ITEM_20151102_008507	Banha de Chaperer
 ITEM_20151102_008508	Banha de Monstro. Pode ser usada para fazer óleo.
-ITEM_20151102_008509	Isca Espécial de Tyronas Hydra
+ITEM_20151102_008509	Isca Especial de Tyronas Hydra
 ITEM_20151102_008510	Isca Completa. Tyronas Hydra adora isso. 
 ITEM_20151102_008511	Saco com Oferendas
 ITEM_20151102_008512	Bússola da Procura Mágica


### PR DESCRIPTION
It still needs to be reviewed.

Please check line 8489 and 8490, the word 'shard' is translated as 'caco', like **Caco vermelho do Lago**. When I see shards in MMOs, like Ark Survival for example, they resemble a perfect crystal like so:

![Crystal Shard](http://img3.wikia.nocookie.net/__cb20090920150129/asheron/images/c/c2/Crystal_Shard_Live.jpg)

So it makes sense to call this **shard** a '**cristal**' or 'Pedaço de xxx'. Review and edit as you like, this is my contribution. I had to change a few things to make the text more readable and I kept monster names as they are (in English).

PS: I had to send a new pull request and close the old ones because I organized my local repository in branches, in order to work with multiple files.